### PR TITLE
Update README.md to use new bin path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Place morse inside your `~/bin` directory
 Alternatively, you can manage this script with [fresh](http://github.com/freshshell):
 
 ```
-$ fresh https://github.com/hackling/morse/blob/master/morse
+$ fresh https://github.com/hackling/morse/blob/master/bin/morse
 ```
 
 ## Usage


### PR DESCRIPTION
The fresh line currently doesn't work as defined in the README.md, this fixes that.
