### PR TITLE
Add ifnone param to detect to handle missing branch

### DIFF
--- a/bin/morse
+++ b/bin/morse
@@ -87,7 +87,7 @@ end
 
 def find_and_cache_branch
   branch_information = JSON.parse(open(semaphore_project_url(:branches)).read)
-  branch_id = (branch_information.detect { |branch| branch['name'] == @git_branch })['id']
+  branch_id = (branch_information.detect(-> { {} }) { |branch| branch['name'] == @git_branch })['id']
   if !branch_id.to_s.empty?
     File.open(@file, 'a') { |file| file.write("\n#{@git_branch}: #{branch_id}") }
     branch_id


### PR DESCRIPTION
In response to [#4](https://github.com/hackling/morse/issues/4)

Added the [_ifnone_](http://www.ruby-doc.org/core-2.1.2/Enumerable.html#method-i-detect) parameter to the detect call so an empty Hash is returned (instead of nil) when no matching branch was found. The parameter needs to respond to `#call` (Method or Proc) so an inline lambda was used.
